### PR TITLE
Add job for multiversion docs

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -58,4 +58,31 @@ jobs:
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+          BRANCH_OR_TAG="${GITHUB_REF##*/}"
+          Rscript - <<EOF
+          pkgdown::deploy_to_branch(
+            new_process = FALSE,
+            subdir = "${BRANCH_OR_TAG}",
+            clean = TRUE
+          )
+          EOF
+
+  multi-version-docs:
+    name: Multi-version docs 📑
+    needs: pkgdown
+    runs-on: ubuntu-20.04
+    if: >
+      github.event_name == 'push'
+        && !contains(github.event.commits[0].message, '[skip docs]')
+    steps:
+      - name: Checkout repo 🛎
+        uses: actions/checkout@v3
+        with:
+          path: ${{ github.event.repository.name }}
+          ref: "gh-pages"
+
+      - name: Create and publish docs ↗️
+        uses: insightsengineering/r-pkgdown-multiversion@v2
+        with:
+          path: ${{ github.event.repository.name }}
+          default-landing-page: "main"


### PR DESCRIPTION
This update publishes documentation for the `devel`, `main`, and `pre-release` branches and adds a dropdown menu to the `pkgdown` documentation so a user can select documentation for a given version of the documentation directly from the website published on Github Pages.

In order to view `devel` and `pre-release` docs, this workflow needs to run on those branches respectively.
